### PR TITLE
Bump orb to 0.1.1, migrate to debian_build_simple, manual-only deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,37 @@
 version: 2.1
 
 orbs:
-  greenzie: greenzie/build_and_publish_debs@volatile
+  greenzie: greenzie/build_and_publish_debs@0.1.1
+
+parameters:
+  manual-deploy:
+    type: boolean
+    default: false
 
 workflows:
   version: 2
   pushbuild:
+    unless: << pipeline.parameters.manual-deploy >>
     jobs:
-      # Build jobs
-      - greenzie/debian_build:
+      - greenzie/debian_build_simple:
           name: "amd_debian_build"
+          context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
+          generate_changelog: true
 
-      # Deployment jobs
-      - greenzie/debian_deploy_experimental:
-          name: "deploy_amd64_greenzie"
+  manualdeploy:
+    when: << pipeline.parameters.manual-deploy >>
+    jobs:
+      - greenzie/debian_build_simple:
+          name: "amd_debian_build"
           context: GREENZIE
-          filters:
-            branches:
-              only:
-                - noetic
+          platform: amd64
+          executor: greenzie/debianize_amd64
+          generate_changelog: true
+
+      - greenzie/debian_deploy_experimental:
+          name: "deploy_all_greenzie"
+          context: GREENZIE
           requires:
             - amd_debian_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,22 +13,20 @@ workflows:
   pushbuild:
     unless: << pipeline.parameters.manual-deploy >>
     jobs:
-      - greenzie/debian_build_simple:
+      - greenzie/debian_build:
           name: "amd_debian_build"
           context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
-          generate_changelog: true
 
   manualdeploy:
     when: << pipeline.parameters.manual-deploy >>
     jobs:
-      - greenzie/debian_build_simple:
+      - greenzie/debian_build:
           name: "amd_debian_build"
           context: GREENZIE
           platform: amd64
           executor: greenzie/debianize_amd64
-          generate_changelog: true
 
       - greenzie/debian_deploy_experimental:
           name: "deploy_all_greenzie"


### PR DESCRIPTION
- Bumps `greenzie/build_and_publish_debs` from `0.0.2` to `0.1.1`
- Replaces removed `greenzie/deploy` job with `greenzie/debian_deploy_experimental`
- Switches to `debian_build_simple` (fixes arm64 apt source issue, sc-51297)
- Deploy is now purely manual (no auto-deploy on branch push)